### PR TITLE
Fix for 'GemSplatModel' object has no attribute 'clip_embeds'

### DIFF
--- a/ns_utils/nerfstudio_utils.py
+++ b/ns_utils/nerfstudio_utils.py
@@ -219,6 +219,9 @@ class GaussianSplat():
             # colors computed from the term of order 0 in the Spherical Harmonic basis
             # coefficient of the order 0th-term in the Spherical Harmonics basis
             pcd_colors_coeff = self.pipeline.model.features_dc
+
+            with torch.no_grad():
+                clip_embeds = self.pipeline.model.clip_field(pcd_points).float()
             
             try:
                 # other attributes of the Gaussian


### PR DESCRIPTION
Hi

Thanks for the great work. 

Here is the fix for Issue #6 as pointed out by my friend [prasadpr09](https://github.com/prasadpr09)